### PR TITLE
Fix carousel bug to prevent error

### DIFF
--- a/client/components/PhotosCarousel.jsx
+++ b/client/components/PhotosCarousel.jsx
@@ -64,6 +64,14 @@ const PhotosCarousel = ({ photos }) => {
     currentPhoto = photos[index];
   };
 
+  if (!currentPhoto) {
+    return (
+      <Carousel>
+        <Slide src='https://zigat.s3-us-west-1.amazonaws.com/no-dish.png' alt="no dish photo" />
+      </Carousel>
+    );
+  }
+
   return (
     <Carousel>
       <Slide src={currentPhoto.url} alt="restaurant photo" />


### PR DESCRIPTION
If a restaurant has no photos, render a placeholder no dish image and remove the arrows in the carousel component.

https://trello.com/c/XG8GOaOb/50-add-placeholder-no-dish-image-if-there-are-no-photos-for-that-restaurant
https://trello.com/c/satBumfi/51-remove-arrows-when-there-is-only-a-placeholder-image-for-a-restaurant